### PR TITLE
refactor: better leaderboard

### DIFF
--- a/src/commands/pat.ts
+++ b/src/commands/pat.ts
@@ -33,7 +33,9 @@ export class Pat {
       return null;
     }
 
-    const sorted = users.data.sort((a, b) => b.pat - a.pat);
+    const sorted = users.data
+      .sort((a, b) => b.pat - a.pat)
+      .filter((v) => v.pat > 0);
 
     const pages: {
       embeds: EmbedBuilder[];


### PR DESCRIPTION
Instead of showing everyones pat level.  Only show the people with a pat level higher than 0.